### PR TITLE
reduce GeoJSON file size

### DIFF
--- a/buildStage3.py
+++ b/buildStage3.py
@@ -235,10 +235,11 @@ def pBuild(row):
   #even though it's unnecessary for many.
   srcShp.schema["geometry"] = "MultiPolygon"
 
+  kwargs = {"COORDINATE_PRECISION":7}
   with fiona.open(geojson, 'w', driver="GeoJSON", 
                   schema=srcShp.schema,
                  encoding='utf-8',
-                 crs=fiona.crs.from_epsg(4326)) as write_geojson:
+                 crs=fiona.crs.from_epsg(4326), **kwargs) as write_geojson:
 
     for feature in srcShp:
       if(feature["geometry"]["type"] == "MultiPolygon"):


### PR DESCRIPTION
Hi, great boundaries. Love to see it. 

Submitting this PR with a suggested tweak to reduce the size of GeoJSON output files 30-40% without sacrificing any practical degree of precision. 

The GeoJSON format specifications suggest [6ish decimal places as a common default](https://tools.ietf.org/html/rfc7946#section-11.2): (precision of ~10cm). Other sources elaborate on the [practical limits of decimal degree precision](https://gis.stackexchange.com/a/8674).  

Passing [parameters from OGR](https://gdal.org/drivers/vector/geojson.html#layer-creation-options) to the fiona Shapefile -> GeoJSON file creation step achieves this with minimal changes to the code. Currently defaults to 15 decimal places, which is unnecessary. Suggesting 7 here to save some bytes. Hoping this can cut down a smidge on bandwidth and storage needs. 

Cheers!