### PR TITLE
deleted humanitarian files for NGA from gB OPEN

### DIFF
--- a/sourceData/gbOpen/NGA_ADM0.zip
+++ b/sourceData/gbOpen/NGA_ADM0.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c8aedbca2997da335396d581ed43616dcce2102fbcf86f0a1e26e524de2ed67
-size 59814

--- a/sourceData/gbOpen/NGA_ADM1.zip
+++ b/sourceData/gbOpen/NGA_ADM1.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a1fd4a84123820009359f35b90eb0ce572a4d3fd691c80f1c0c2ec8948f5b80
-size 380730

--- a/sourceData/gbOpen/NGA_ADM2.zip
+++ b/sourceData/gbOpen/NGA_ADM2.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36e0939d4c7b090b79f0d2ce4630bed80eee5f8d2fbc6c7fedb0af724e6e2518
-size 1103843


### PR DESCRIPTION
The files were not deleted from gB OPEN after being moved to gB Humanitarian.