### PR TITLE
Update GHA_ADM0.zip

### DIFF
--- a/sourceData/gbOpen/GHA_ADM0.zip
+++ b/sourceData/gbOpen/GHA_ADM0.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa03f85e844f694a222cac47ce1e87eedef47c6de565fbdb49e1d146972d4b06
-size 34587
+oid sha256:c0d70772d12bb4d228077697367c8bcd8f7b6709c12fbba64aeb70f0cd2d2e33
+size 550778


### PR DESCRIPTION
Updated GHA_ADM0 with an appropriate license for gbOpen

<!--- If you are submitting a boundary, Please include your ISO code and ADM level in the title --> GHA_ADM0
<!--- This PR template is for boundary submissions; if you are submitting code please give us as much detail as possible. -->

## Why do we need this boundary?  
<!--- If this is in response to a github issue, just link it here. -->https://github.com/wmgeolab/gbRelease/issues/90

## Anything Unusual?
<!--- Please describe any known complications with your submission. -->
<!--- You can also include anything else we need to know while assessing this data. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My submission is either a shapefile (with all the relevant files) or a geojson.
- [ x] I have included a file named "meta.txt", with all required metadata (see an example in https://bit.ly/2GtQ01i).
- [x ] I have included a file named "license.png" or "license.jpg", which includes a screenshot of the loaded website (or other source) with the licensure information.
- [x ] Everything is zipped up in a single file following the naming convention "ISO_ADMN.zip", and I am requesting it be added to the correct folder (i.e., gbOpen).
